### PR TITLE
json-encoder: cannot convert `schema?` to JSON

### DIFF
--- a/src/clojure/abracad/avro.clj
+++ b/src/clojure/abracad/avro.clj
@@ -242,7 +242,7 @@ decoded serially from `source`."
   "Return a JSON-encoding encoder for `sink` using `schema`."
   {:tag `Encoder}
   [schema sink]
-  (let [schema (parse-schema schema?)]
+  (let [schema (parse-schema schema)]
     (encoder-factory jsonEncoder schema ^OutputStream sink)))
 
 (defn encode

--- a/test/abracad/avro_test.clj
+++ b/test/abracad/avro_test.clj
@@ -8,6 +8,9 @@
 (defn roundtrip
   [schema & records]
   (->> (apply avro/binary-encoded schema records)
+       (avro/decode-seq schema)
+       (apply avro/json-encoded schema)
+       (avro/json-decoder schema)
        (avro/decode-seq schema)))
 
 (defrecord Example [foo-foo bar])


### PR DESCRIPTION
There was a typo in the implementation of `json-encoder`, which wasn't being picked up in tests as they only roundtrip with binary encoding. This PR fixes the typo and adds JSON to the `roundtrip` function so that the tests cover it.
