### PR TITLE
This fixes a problem when used with Apache Spark / AOT compiled code.

### DIFF
--- a/src/clojure/abracad/avro/read.clj
+++ b/src/clojure/abracad/avro/read.clj
@@ -6,7 +6,8 @@
              :refer [mangle unmangle field-keyword if-not-let]])
   (:import [org.apache.avro Schema Schema$Field]
            [org.apache.avro.io Decoder ResolvingDecoder]
-           [abracad.avro ClojureDatumReader ArrayAccessor]))
+           [abracad.avro ClojureDatumReader ArrayAccessor]
+           ))
 
 (defn schema-symbol
   [^Schema schema]
@@ -21,7 +22,9 @@ indicating schema name."
 
 (defn record-reader
   "Generate wrapper for provided Avro reader function."
-  [f] (fn [_ record] (apply f record)))
+  [f]
+  (require [(ns-name (.ns f))])
+  (fn [_ record] (apply f record)))
 
 (defn reader-fn
   "Return tuple of `(named?, readerf)` for provided Avro `schema` and
@@ -30,11 +33,11 @@ schema name symbol `rname`."
   (if-let [f (get avro/*avro-readers* rname)]
     [false (record-reader f)]
     (if-not-let [reader (.getProp schema "abracad.reader")]
-      [true record-plain]
-      (case reader
-        "vector" [false record-plain]
-        #_else   (throw (ex-info "unknown `abracad.reader`"
-                                 {:reader reader}))))))
+                [true record-plain]
+                (case reader
+                  "vector" [false record-plain]
+                  #_else (throw (ex-info "unknown `abracad.reader`"
+                                         {:reader reader}))))))
 
 (defn read-record
   [^ClojureDatumReader reader ^Schema expected ^ResolvingDecoder in]
@@ -43,8 +46,8 @@ schema name symbol `rname`."
         [reducef record] (if named?
                            [(fn [m ^Schema$Field f]
                               (assoc! m
-                                (field-keyword f)
-                                (.read reader nil (.schema f) in)))
+                                      (field-keyword f)
+                                      (.read reader nil (.schema f) in)))
                             (transient {})]
                            [(fn [v ^Schema$Field f]
                               (conj! v (.read reader nil (.schema f) in)))
@@ -61,11 +64,11 @@ schema name symbol `rname`."
   (if-not (pos? n)
     []
     (persistent!
-     (loop [m (transient []), n (long n)]
-       (let [m (conj! m (.read reader nil expected in)), n (dec n)]
-         (if-not (pos? n)
-           (let [n (.arrayNext in)] (if-not (pos? n) m (recur m n)))
-           (recur m n)))))))
+      (loop [m (transient []), n (long n)]
+        (let [m (conj! m (.read reader nil expected in)), n (dec n)]
+          (if-not (pos? n)
+            (let [n (.arrayNext in)] (if-not (pos? n) m (recur m n)))
+            (recur m n)))))))
 
 (defn read-array
   [^ClojureDatumReader reader ^Schema expected ^ResolvingDecoder in]
@@ -89,12 +92,12 @@ schema name symbol `rname`."
     (if-not (pos? n)
       {}
       (persistent!
-       (loop [m (transient {}), n (long n)]
-         (let [k (.readString in), v (.read reader nil vtype in)
-               m (assoc! m k v), n (dec n)]
-           (if-not (pos? n)
-             (let [n (.mapNext in)] (if-not (pos? n) m (recur m n)))
-             (recur m n))))))))
+        (loop [m (transient {}), n (long n)]
+          (let [k (.readString in), v (.read reader nil vtype in)
+                m (assoc! m k v), n (dec n)]
+            (if-not (pos? n)
+              (let [n (.mapNext in)] (if-not (pos? n) m (recur m n)))
+              (recur m n))))))))
 
 (defn read-fixed
   [^ClojureDatumReader reader ^Schema expected ^Decoder in]


### PR DESCRIPTION
Hi!

I had a problem using custom avro-readers in Spark, as the record_reader attempted to call an unbound function (See stack trace below).

Requiring the namespace of the var (line 26) fixed the problem.

Apparently, it has something to do with AOT-compilation, though I wasn't able to reproduce the error in a test case with proper effort. :(

I also hit format code, so sorry, some whitespaces are different. It's only the new line 26 I added.

Sincerly,

Chris



2015-04-02 11:56:00.314 [Result resolver thread-1                ] WARN  org.apache.spark.scheduler.TaskSetManager                   : Lost task 0.1 in stage 1.0 (TID 5, trillian.pmd.local): java.lang.IllegalStateException: Attempting to call unbound fn: #'pmd.pacs.data.impression.rdd/performance-data-item-from-impressions
        clojure.lang.Var$Unbound.throwArity(Var.java:43)
        clojure.lang.AFn.invoke(AFn.java:62)
        clojure.lang.Var.invoke(Var.java:430)
        clojure.lang.AFn.applyToHelper(AFn.java:195)
        clojure.lang.Var.applyTo(Var.java:700)
        clojure.core$apply.invoke(core.clj:628)
        abracad.avro.read$record_reader$fn__302.invoke(read.clj:24)
        abracad.avro.read$read_record.invoke(read.clj:53)
        clojure.lang.Var.invoke(Var.java:388)
        abracad.avro.ClojureDatumReader.readRecord(ClojureDatumReader.java:57)
        org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:151)
        abracad.avro.ClojureDatumReader.read(ClojureDatumReader.java:50)
        org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:142)
        org.apache.avro.file.DataFileStream.next(DataFileStream.java:233)
        org.apache.avro.mapreduce.AvroRecordReaderBase.nextKeyValue(AvroRecordReaderBase.java:118)
        sparkling.hadoop.ClojureAvroRecordReader.nextKeyValue(ClojureAvroRecordReader.java:27)