### PR TITLE
Add abracad.avro/data-file-stream

### DIFF
--- a/src/clojure/abracad/avro.clj
+++ b/src/clojure/abracad/avro.clj
@@ -11,7 +11,7 @@
            [clojure.lang Named]
            [org.apache.avro Schema Schema$Parser Schema$Type]
            [org.apache.avro.file
-             CodecFactory DataFileWriter DataFileReader SeekableInput
+             CodecFactory DataFileWriter DataFileReader DataFileStream SeekableInput
              SeekableFileInput SeekableByteArrayInput]
            [org.apache.avro.io
              DatumReader DatumWriter Decoder DecoderFactory
@@ -146,6 +146,14 @@ but the first `n` fields when sorting."
   ([expected source]
      (DataFileReader/openReader
       (seekable-input source) (datum-reader expected))))
+
+(defn data-file-stream
+  "Return an Avro DataFileStream which produces Clojure data structures."
+  {:tag `DataFileStream}
+  ([source] (data-file-stream nil source))
+  ([expected source]
+     (DataFileStream.
+       (io/input-stream source) (datum-reader expected))))
 
 (defmacro ^:private decoder-factory
   "Invoke static methods of default Avro Decoder factory."

--- a/test/abracad/avro_test.clj
+++ b/test/abracad/avro_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [abracad.avro :as avro]
             [clojure.java.io :as io])
-  (:import [java.io ByteArrayOutputStream]
+  (:import [java.io ByteArrayOutputStream FileInputStream]
            [java.net InetAddress]
            [org.apache.avro SchemaParseException]
            [clojure.lang ExceptionInfo]))
@@ -266,3 +266,12 @@
     (io/make-parents path)
     (avro/mspit schema path records)
     (is (= records (avro/mslurp path)))))
+
+(deftest test-data-file-stream
+  (let [path "tmp/data-file-stream.avro"
+        schema {:type :long}
+        records [0 1 2 3 4 5]]
+    (io/make-parents path)
+    (avro/mspit schema path records)
+    (with-open [dfs (avro/data-file-stream (FileInputStream. path))]
+      (is (= records (seq dfs))))))


### PR DESCRIPTION
This parallels the existing `data-file-reader` in constructucting an
`org.apache.avro.file.DataFileStream` which is useful for streaming
access to (potentially-remote) files. We've found this useful for reading
files on e.g. S3.