### PR TITLE
Automatically load Avro reader var namespaces

### DIFF
--- a/src/clojure/abracad/avro/read.clj
+++ b/src/clojure/abracad/avro/read.clj
@@ -4,7 +4,8 @@
   (:require [abracad.avro :as avro]
             [abracad.avro.util
              :refer [mangle unmangle field-keyword if-not-let]])
-  (:import [org.apache.avro Schema Schema$Field]
+  (:import [clojure.lang Var]
+           [org.apache.avro Schema Schema$Field]
            [org.apache.avro.io Decoder ResolvingDecoder]
            [abracad.avro ClojureDatumReader ArrayAccessor]))
 
@@ -105,3 +106,10 @@ schema name symbol `rname`."
 (defn read-bytes
   [^ClojureDatumReader reader ^Schema expected ^Decoder in]
   (.array (.readBytes in nil)))
+
+;; Load namespaces in order to ensure Avro reader vars are available
+(doseq [ns (->> (vals avro/*avro-readers*)
+                (map #(-> ^Var % .-ns .-name))
+                (distinct)
+                (sort))]
+  (require ns))


### PR DESCRIPTION
Spark in particular but potentially other JVM frameworks as well do not provide any convenient hooks we could use to load Avro reader var namespaces prior to the framework performing Avro deserialization.  With this change, we work around the problem by loading configured Avro reader var namespaces upon first using a `ClojureDatumReader` instance.