### PR TITLE
Pick the matching union record type with the fewest fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
-script: lein2 test-all
+lein: lein
+script: lein test-all
 jdk:
   - openjdk7

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.7" "-source" "1.7"]
   :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/math.numeric-tower "0.0.4"]
                  [org.apache.avro/avro "1.8.0"]
                  [cheshire/cheshire "5.6.1"]]
   :plugins [[codox/codox "0.6.4"]]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,6 @@
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.7" "-source" "1.7"]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/math.numeric-tower "0.0.4"]
                  [org.apache.avro/avro "1.8.0"]
                  [cheshire/cheshire "5.6.1"]]
   :plugins [[codox/codox "0.6.4"]]

--- a/src/clojure/abracad/avro/write.clj
+++ b/src/clojure/abracad/avro/write.clj
@@ -5,7 +5,7 @@
             [abracad.avro.edn :as edn]
             [abracad.avro.util :refer [case-expr case-enum mangle unmangle
                                        field-keyword]]
-            [clojure.math.numeric-tower :refer [abs]])
+            [clojure.set])
   (:import [java.util Collection Map List]
            [java.nio ByteBuffer]
            [clojure.lang Named Sequential IRecord Indexed]
@@ -211,8 +211,7 @@ record serialization."
 (defn avro-record-score
   [^Schema schema datum]
   (cond
-    (vector? datum) (abs (- (count datum)
-                            (-> schema .getFields count)))
+    (vector? datum) (when (= (count datum) (-> schema .getFields count)) 0)
     (map? datum) (let [schema-fields (->> schema .getFields (map field-keyword) set)
                        datum-fields (avro/field-list datum)]
                    (when (clojure.set/subset? datum-fields schema-fields)
@@ -259,7 +258,6 @@ record serialization."
   (let [n (if (element-union? schema)
             (edn/schema-name datum)
             (avro/schema-name datum))]
-
     (if-let [index (and n (.getIndexNamed schema n))]
       index
       (let [winner (->> (.getTypes schema)

--- a/test/abracad/avro_test.clj
+++ b/test/abracad/avro_test.clj
@@ -4,7 +4,7 @@
             [clojure.java.io :as io])
   (:import [java.io ByteArrayOutputStream FileInputStream]
            [java.net InetAddress]
-           [org.apache.avro SchemaParseException]
+           [org.apache.avro SchemaParseException UnresolvedUnionException]
            [clojure.lang ExceptionInfo]))
 
 (defn roundtrip-binary
@@ -133,7 +133,7 @@
                     :fields [{:name 'string, :type 'string}]}
           schema (avro/parse-schema [example1 example2])
           records [{:long 0 :string "string"}]]
-      (is (thrown? org.apache.avro.UnresolvedUnionException
+      (is (thrown? UnresolvedUnionException
                    (apply roundtrip-binary schema records)))))
 
   (testing "when multiple record types match, that with the fewest fields is chosen"

--- a/test/abracad/avro_test.clj
+++ b/test/abracad/avro_test.clj
@@ -126,6 +126,33 @@
     (is (= '[example1 example2]
            (map (comp :type meta) records')))))
 
+(deftest test-union-record-subset-of-other-record
+  (let [example1 {:type :record, :name 'example1,
+                  :fields [{:name 'long, :type 'long}
+                           {:name 'string, :type 'string}]}
+        example2 {:type :record, :name 'example2,
+                  :fields [{:name 'string, :type 'string}]}
+        schema (avro/parse-schema [example1 example2])
+        records [{:long 0 :string "string"}
+                 {:string "string"}]
+        records' (apply roundtrip-binary schema records)]
+    (is (= records records'))
+    (is (= '[example1 example2]
+           (map (comp :type meta) records'))))
+
+  (let [example1 {:type :record, :name 'example1,
+                  :fields [{:name 'string, :type 'string}]}
+        example2 {:type :record, :name 'example2,
+                  :fields [{:name 'long, :type 'long}
+                           {:name 'string, :type 'string}]}
+        schema (avro/parse-schema [example1 example2])
+        records [{:long 0 :string "string"}
+                 {:string "string"}]
+        records' (apply roundtrip-binary schema records)]
+    (is (= records records'))
+    (is (= '[example2 example1]
+           (map (comp :type meta) records')))))
+
 (deftest test-bytes
   (let [schema (avro/parse-schema
                 [{:type :fixed, :name "foo", :size 1}, :bytes])

--- a/test/abracad/avro_test.clj
+++ b/test/abracad/avro_test.clj
@@ -124,34 +124,44 @@
         records' (apply roundtrip-binary schema records)]
     (is (= records records'))
     (is (= '[example1 example2]
-           (map (comp :type meta) records')))))
-
-(deftest test-union-record-subset-of-other-record
-  (let [example1 {:type :record, :name 'example1,
-                  :fields [{:name 'long, :type 'long}
-                           {:name 'string, :type 'string}]}
-        example2 {:type :record, :name 'example2,
-                  :fields [{:name 'string, :type 'string}]}
-        schema (avro/parse-schema [example1 example2])
-        records [{:long 0 :string "string"}
-                 {:string "string"}]
-        records' (apply roundtrip-binary schema records)]
-    (is (= records records'))
-    (is (= '[example1 example2]
            (map (comp :type meta) records'))))
 
-  (let [example1 {:type :record, :name 'example1,
-                  :fields [{:name 'string, :type 'string}]}
-        example2 {:type :record, :name 'example2,
-                  :fields [{:name 'long, :type 'long}
-                           {:name 'string, :type 'string}]}
-        schema (avro/parse-schema [example1 example2])
-        records [{:long 0 :string "string"}
-                 {:string "string"}]
-        records' (apply roundtrip-binary schema records)]
-    (is (= records records'))
-    (is (= '[example2 example1]
-           (map (comp :type meta) records')))))
+  (testing "no record type is selected if none is suitable"
+    (let [example1 {:type   :record, :name 'example1,
+                    :fields [{:name 'long, :type 'long}]}
+          example2 {:type   :record, :name 'example2,
+                    :fields [{:name 'string, :type 'string}]}
+          schema (avro/parse-schema [example1 example2])
+          records [{:long 0 :string "string"}]]
+      (is (thrown? org.apache.avro.UnresolvedUnionException
+                   (apply roundtrip-binary schema records)))))
+
+  (testing "when multiple record types match, that with the fewest fields is chosen"
+    (let [example1 {:type :record, :name 'example1,
+                    :fields [{:name 'long, :type 'long}
+                             {:name 'string, :type 'string}]}
+          example2 {:type :record, :name 'example2,
+                    :fields [{:name 'string, :type 'string}]}
+          schema (avro/parse-schema [example1 example2])
+          records [{:long 0 :string "string"}
+                   {:string "string"}]
+          records' (apply roundtrip-binary schema records)]
+      (is (= records records'))
+      (is (= '[example1 example2]
+             (map (comp :type meta) records'))))
+
+    (let [example1 {:type :record, :name 'example1,
+                    :fields [{:name 'string, :type 'string}]}
+          example2 {:type :record, :name 'example2,
+                    :fields [{:name 'long, :type 'long}
+                             {:name 'string, :type 'string}]}
+          schema (avro/parse-schema [example1 example2])
+          records [{:long 0 :string "string"}
+                   {:string "string"}]
+          records' (apply roundtrip-binary schema records)]
+      (is (= records records'))
+      (is (= '[example2 example1]
+             (map (comp :type meta) records'))))))
 
 (deftest test-bytes
   (let [schema (avro/parse-schema


### PR DESCRIPTION
Consider the following schema:

```clj
(def s (avro/parse-schema [{:type   :record, :name 'example1,
                            :fields [{:name 'long, :type 'long}
                                     {:name 'string, :type 'string}]}
                           {:type   :record, :name 'example2,
                            :fields [{:name 'string, :type 'string}]}]))
```
Note that the fields from the second record type are are a subset of those from the first.

Now, if I try this:

```clj
(avro/decode s (avro/binary-encoded s {:string "string"}))
```
I end up with an error `java.lang.NullPointerException: null of long of example1 of example1 of union of union`. The reason for this is that `resolve-union` just picks the first record type that could be used to encode the given datum - in this case that's the *first* record type which is expecting *two* fields, not just the one I've specified.

So, this PR attempts to rectify this by "scoring" each union record type (based on how closely it matches the datum - i.e. assuming that a matching record type with a fewer number of fields is more desirable) and picking the schema with the "best" score.

Some points to note:
* I could find nowhere in the avro specification that explicitly states what should actually happen in this situation.
* This could potentially break backward compatibility for those users of abracad that relied (explicitly or implicitly) on the old record type selection algorithm. Normally I'd "feature flag" it with a config value but since there's no config as such for abracad that's not realistic. One alternative could be to have a dynamic binding (e.g. `*prefer-smaller-union-record-types*`) which would be used to branch the code depending using the old algorithma and the new.
* An alternative workaround to this PR is just to ensure that the union record types defined in your union are defined in the order of precedence. Of course, this is only a workaround if you have control of the schema.

Thoughts?